### PR TITLE
V0.2.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,21 +8,21 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.6, 3.7, 3.8]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
-    - name: Install  Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install virtualenv
-        python -m venv env
-        source env/bin/activate
-        pip install -r requirements-dev.txt
-        pip install -r requirements.txt
-    - name: Test with pytest
-      run: |
-        source env/bin/activate
-        python -m pytest tests/
+      - uses: actions/checkout@v2
+      - name: Set up Python${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Install  Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install virtualenv
+          python -m venv env
+          source env/bin/activate
+          pip install -r requirements-dev.txt
+          pip install -r requirements.txt
+      - name: Test with pytest
+        run: |
+          source env/bin/activate
+          python -m pytest tests/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,35 @@
 repos:
--   repo: https://github.com/python/black
+  - repo: https://github.com/python/black
     rev: 19.10b0
     hooks:
-    -   id: black
--   repo: https://github.com/asottile/seed-isort-config
+      - id: black
+
+  - repo: https://github.com/asottile/seed-isort-config
     rev: v2.1.1
     hooks:
-    -   id: seed-isort-config
--   repo: https://github.com/pre-commit/mirrors-isort
+      - id: seed-isort-config
+
+  - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:
-    -   id: isort
+      - id: isort
         additional_dependencies: [toml]
--   repo: https://github.com/pre-commit/mirrors-mypy
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.770
     hooks:
-    -   id: mypy
--   repo: https://github.com/hakancelik96/unimport
+      - id: mypy
+        exclude: __main__.py
+
+  - repo: https://github.com/hakancelik96/unimport
     rev: v0.2.5
     hooks:
-    -   id: unimport
+      - id: unimport
         args: [-r]
         exclude: rare_cases/
+
+  - repo: https://github.com/prettier/prettier
+    rev: 1.19.1
+    hooks:
+      - id: prettier
+        args: [--prose-wrap=always, --print-width=88]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
--   id: unimport
-    name: unimport
-    description: 'A linter & formatter for finding & removing unused import statements'
-    entry: unimport
-    language: python
-    language_version: python3
-    verbose: true
-    types: [python]
+- id: unimport
+  name: unimport
+  description: "A linter & formatter for finding & removing unused import statements"
+  entry: unimport
+  language: python
+  language_version: python3
+  verbose: true
+  types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [0.2.6]
 
 - 💪 `--include-star-import command add` Include star imports during scanning and
   refactor.
@@ -13,6 +13,15 @@ All notable changes to this project will be documented in this file.
   longer be offered as suggestions for star import.
 
 - 🐞 If there is no unused import, the refactor error has been fixed.
+
+- 💪 Import skip feature has been added. Leave '#unimport: skip' at the end of the line
+  to skip imports with some rare cases. **for example:**
+  ```python
+  try:
+    import django #unimport:skip
+  except ImportError:
+    print("install django")
+  ```
 
 ## [0.2.5] - 16/May/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.6]
 
+[0.2.6 by @hakancelik96](https://github.com/hakancelik96/unimport/pull/32)
+
 - 💪 `--include-star-import command add` Include star imports during scanning and
   refactor.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,72 +1,104 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- 💪 `--include-star-import command add` Include star imports during scanning and
+  refactor.
+
+- 🌈 color_diff add It shows the difference between source and refactor better.
+
+- 🐞 All builtins names received during the scan have been fixed. Builtins names will no
+  longer be offered as suggestions for star import.
+
+- 🐞 If there is no unused import, the refactor error has been fixed.
+
 ## [0.2.5] - 16/May/2020
+
 [0.2.5 by @hakancelik96](https://github.com/hakancelik96/unimport/pull/31)
+
 - 💪 Refactor code rewrite using libcst.
 - 🐞 Refactor bugs fix.
-- 🧪 [Comma rare case support & test.](https://github.com/hakancelik96/unimport/blob/b8800ec19441bbc452900e1c8b558bea2e43d065/rare_cases/case_comma.py)
+- 🧪
+  [Comma rare case support & test.](https://github.com/hakancelik96/unimport/blob/b8800ec19441bbc452900e1c8b558bea2e43d065/rare_cases/case_comma.py)
 - 💪 pre-commit add & support
 - 🐞 Add Sytranx Error Catcher
 
 ## [0.2.4] - 17/April/2020
-- 💪 [As import refactor support by @hakancelik96](https://github.com/hakancelik96/unimport/commit/147ed5e836d6a4589a92db4157bfd299ca935b02)
-- 💪 [Duplicate detect and refactor support by @hakancelik96](https://github.com/hakancelik96/unimport/pull/23)
+
+- 💪
+  [As import refactor support by @hakancelik96](https://github.com/hakancelik96/unimport/commit/147ed5e836d6a4589a92db4157bfd299ca935b02)
+- 💪
+  [Duplicate detect and refactor support by @hakancelik96](https://github.com/hakancelik96/unimport/pull/23)
 
 ## [0.2.2] - 4/April/2020
-- 🐞 [Fix: Scan & Config - Add test to default exlude by @hakancelik96](https://github.com/hakancelik96/unimport/commit/7e789872917c51e5ffa167d26581e5397fd34998)
+
+- 🐞
+  [Fix: Scan & Config - Add test to default exlude by @hakancelik96](https://github.com/hakancelik96/unimport/commit/7e789872917c51e5ffa167d26581e5397fd34998)
 
 ## [0.2.1] - 8/March/2020
-💪 from x import * support
+
+💪 from x import \* support
+
 - [issue; #19](https://github.com/hakancelik96/unimport/issues/19)
 - [PR; #21](https://github.com/hakancelik96/unimport/pull/21) by @hakancelik96
 
 ## [0.2.0] - 19/Jan/2020
+
 - 💪 Argparse support.
-    - [implement an initial arg parser by @gkmngrgn](https://github.com/hakancelik96/unimport/commit/4e5fbd778112704626c8d708a1077d7d1f345157)
-    - [argparse support by @gkmngrgn](https://github.com/hakancelik96/unimport/commit/837af61fab771b4a09893a7854df42452de7aff9)
-    - [argparse (#4) by @isidentical](https://github.com/hakancelik96/unimport/commit/90cfab776d3e15b417d1566f7ca1b1e2756763dd)
-    - Arguments
-        - ["-w" / "--write" parameter is fixed in this PR (#9) by @gkmngrgn](https://github.com/hakancelik96/unimport/commit/5c59f938d3ef3844a5420882ad318a120e4da4af)
-        - [#12 diff option & and overwrite permission add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/36e7216cd6cc442864460d7b2b7661190c627757)
-        - [#12 -dw add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/57913e0fb47073f4473e5694470cc2ee9dffdfb6)
-        - [#12 bug fix & Some functions have been moved to the corresponding files @hakancelik96](https://github.com/hakancelik96/unimport/commit/188370fc7928588a48e9e3dcd0ee70f9f12b733e)
-        - [--version add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/2112e44e45bc0b34e330bc5320bbcd1462257f1e)
-        - [Console Argument (#17) by @hakancelik96](https://github.com/hakancelik96/unimport/commit/e4db14dbc74fbc8a51c5d1f62ca9d679af05af9b)
+
+  - [implement an initial arg parser by @gkmngrgn](https://github.com/hakancelik96/unimport/commit/4e5fbd778112704626c8d708a1077d7d1f345157)
+  - [argparse support by @gkmngrgn](https://github.com/hakancelik96/unimport/commit/837af61fab771b4a09893a7854df42452de7aff9)
+  - [argparse (#4) by @isidentical](https://github.com/hakancelik96/unimport/commit/90cfab776d3e15b417d1566f7ca1b1e2756763dd)
+  - Arguments
+    - ["-w" / "--write" parameter is fixed in this PR (#9) by @gkmngrgn](https://github.com/hakancelik96/unimport/commit/5c59f938d3ef3844a5420882ad318a120e4da4af)
+    - [#12 diff option & and overwrite permission add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/36e7216cd6cc442864460d7b2b7661190c627757)
+    - [#12 -dw add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/57913e0fb47073f4473e5694470cc2ee9dffdfb6)
+    - [#12 bug fix & Some functions have been moved to the corresponding files @hakancelik96](https://github.com/hakancelik96/unimport/commit/188370fc7928588a48e9e3dcd0ee70f9f12b733e)
+    - [--version add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/2112e44e45bc0b34e330bc5320bbcd1462257f1e)
+    - [Console Argument (#17) by @hakancelik96](https://github.com/hakancelik96/unimport/commit/e4db14dbc74fbc8a51c5d1f62ca9d679af05af9b)
 
 - 🐞 Tests
-    - [fix_multiple_problems_at_once_action.py by @hakancelik96](https://github.com/hakancelik96/unimport/commit/aee62041b2d625cef0d723c526d5db28d96ce2fd)
-    - [test_overwrite source_expected path bug fix by @hakancelik96](https://github.com/hakancelik96/unimport/commit/63645dbb4333b3675e57bbc99bddfa133eb33594)
+
+  - [fix_multiple_problems_at_once_action.py by @hakancelik96](https://github.com/hakancelik96/unimport/commit/aee62041b2d625cef0d723c526d5db28d96ce2fd)
+  - [test_overwrite source_expected path bug fix by @hakancelik96](https://github.com/hakancelik96/unimport/commit/63645dbb4333b3675e57bbc99bddfa133eb33594)
 
 - 💪 Configuration
-    - [example_configuration add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/70c70ba0d5ac8f200986c5c0a57acc8ccc574dab)
-    - [#8 & glob configuration by @hakancelik96](https://github.com/hakancelik96/unimport/commit/c8bd58e28855886c5908a626260820c3894a4600)
-    - [ignore config name change as exclude by @hakancelik96](https://github.com/hakancelik96/unimport/commit/aef61eb3ddf0c295719dc840390fba16e3d5e3e9)
-    - [remove .unimport.cfg by @hakancelik96](https://github.com/hakancelik96/unimport/commit/b052ffb336bc0f73a723f5f4938cb7ffb81cd038)
-    - [find_config bug fix & console config argument bug fix by @hakancelik96](https://github.com/hakancelik96/unimport/commit/860d57791a36c54e1830439bf9e571b1cb608123)
+
+  - [example_configuration add by @hakancelik96](https://github.com/hakancelik96/unimport/commit/70c70ba0d5ac8f200986c5c0a57acc8ccc574dab)
+  - [#8 & glob configuration by @hakancelik96](https://github.com/hakancelik96/unimport/commit/c8bd58e28855886c5908a626260820c3894a4600)
+  - [ignore config name change as exclude by @hakancelik96](https://github.com/hakancelik96/unimport/commit/aef61eb3ddf0c295719dc840390fba16e3d5e3e9)
+  - [remove .unimport.cfg by @hakancelik96](https://github.com/hakancelik96/unimport/commit/b052ffb336bc0f73a723f5f4938cb7ffb81cd038)
+  - [find_config bug fix & console config argument bug fix by @hakancelik96](https://github.com/hakancelik96/unimport/commit/860d57791a36c54e1830439bf9e571b1cb608123)
 
 - 💪 Lib2to3 support
-    - [Initial lib2to3 refactor by @isidentical](https://github.com/hakancelik96/unimport/commit/9030cb2fea518aa9fb887a5d4ef1bb8b34947ed9)
-    - [add support for name binding by @isidentical](https://github.com/hakancelik96/unimport/commit/4a3df83b5b89d00472bed292c23b20693bdf5dd2)
-    - [adapt testing suite by @isidentical](https://github.com/hakancelik96/unimport/commit/c81036fe5b0d845c3220cfda1e4c30250e1107a1)
+
+  - [Initial lib2to3 refactor by @isidentical](https://github.com/hakancelik96/unimport/commit/9030cb2fea518aa9fb887a5d4ef1bb8b34947ed9)
+  - [add support for name binding by @isidentical](https://github.com/hakancelik96/unimport/commit/4a3df83b5b89d00472bed292c23b20693bdf5dd2)
+  - [adapt testing suite by @isidentical](https://github.com/hakancelik96/unimport/commit/c81036fe5b0d845c3220cfda1e4c30250e1107a1)
 
 - 🐞 Bug Fix
-    - [setup.cfg bug fix & catch error in detect by @hakancelik96](https://github.com/hakancelik96/unimport/commit/a99b3846d55b723a701d6fdbbc7e634772b8c5ba)
-    - [get_files bug fix by @hakancelik96](https://github.com/hakancelik96/unimport/commit/3d3299f1c82161a8e95d909864ad00dd9fda23f9)
-    - [support local imports by @hakancelik96 and @isidentical](https://github.com/hakancelik96/unimport/commit/8c9b12295cf7c87670a685e59f95f1d83da130f7)
+
+  - [setup.cfg bug fix & catch error in detect by @hakancelik96](https://github.com/hakancelik96/unimport/commit/a99b3846d55b723a701d6fdbbc7e634772b8c5ba)
+  - [get_files bug fix by @hakancelik96](https://github.com/hakancelik96/unimport/commit/3d3299f1c82161a8e95d909864ad00dd9fda23f9)
+  - [support local imports by @hakancelik96 and @isidentical](https://github.com/hakancelik96/unimport/commit/8c9b12295cf7c87670a685e59f95f1d83da130f7)
 
 - 💊 Optimization
-    - [balamir by @hakancelik96 and @isidentical](https://github.com/hakancelik96/unimport/commit/d4c1594371e7d3a3646cf2d886e931b50ca104f6)
+
+  - [balamir by @hakancelik96 and @isidentical](https://github.com/hakancelik96/unimport/commit/d4c1594371e7d3a3646cf2d886e931b50ca104f6)
 
 - 💪 API Support
-    - [General API Cleanup by @isidentical](https://github.com/hakancelik96/unimport/commit/f3efe4720eaa4eef5d991f838a0bd0872661dfa3)
+  - [General API Cleanup by @isidentical](https://github.com/hakancelik96/unimport/commit/f3efe4720eaa4eef5d991f838a0bd0872661dfa3)
 
 ## [0.1.3] - 31/Oct/2019
+
 - 💪 pyproject.toml support
 - 💪 setup.cfg support
 - 🧪 test written
 
 ### [0.1.0] - 27/Sep/2019
+
 - 🎉 Some class and function name and position changed.
 - 🎉 Future module added to the ignore list.
 - 🐞 Blank python file error fix.
@@ -74,15 +106,19 @@ All notable changes to this project will be documented in this file.
 - The new usage style `unimport` to scan from current path
 
 ### [0.0.3] - 22/Sep/2019
+
 - 🐞 Op system bug fix Linux and win
 - 🐞 File and folders features fix
-- 💪 Add warning message if no enter any path No paths given 'Usage; unimport {source_file_or_directory}'"
+- 💪 Add warning message if no enter any path No paths given 'Usage; unimport
+  {source_file_or_directory}'"
 
 ### [0.0.2] - 21/Sep/2019
-- 🐞 find module bug fix;
-For example; module: inspect, name; inspect.getsource; result unused import = inspect that is the wrong result
+
+- 🐞 find module bug fix; For example; module: inspect, name; inspect.getsource; result
+  unused import = inspect that is the wrong result
 
 ### [0.0.1] - 19/Sep/2019
+
 - unimport {source_file_or_directory}
 - .unimport.cfg 'type the names of files or folders that you do not want to scan.'
 - Does not replace files only shows results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,23 @@ All notable changes to this project will be documented in this file.
 
 - 💪 Import skip feature has been added. Leave '#unimport: skip' at the end of the line
   to skip imports with some rare cases. **for example:**
+
   ```python
   try:
     import django #unimport:skip
   except ImportError:
     print("install django")
   ```
+
+- 💪 Added support for the rare case of **all**. **for example:**
+
+  ```python
+  from codeop import compile_command
+  __all__ = ["compile_command"]
+  ```
+
+Thanks to this feature, we take the values ​​in the `__all__` list and see if there is
+any matching import statements. If there isn't, this import is unused import.
 
 ## [0.2.5] - 16/May/2020
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 ## Development and Contributing
 
 ## Issue
+
 To make an improvement, add a new feature or anything else, please open a issue first.
 
 ## Setup
+
 Then by setting up and activating a virtualenv:
 
 ```
@@ -17,7 +19,9 @@ git checkout -b i{your issue number}
 ```
 
 ## Commit messages
-If you want, you can use the emoji about the commit message you will throw, this can help us better understand the change you have made and also it is fun.
+
+If you want, you can use the emoji about the commit message you will throw, this can
+help us better understand the change you have made and also it is fun.
 
 - When you make any support commit; 💪
 - When you make any tests commit; 🧪
@@ -25,12 +29,16 @@ If you want, you can use the emoji about the commit message you will throw, this
 - When you make any optimizasiyon commit; 💊
 
 ## Formatting
-We use isort, black and of course unimport to format code. To all format changes to be conformant, run the following in the root:
+
+We use isort, black and of course unimport to format code. To all format changes to be
+conformant, run the following in the root:
+
 ```
 pre-commit run --all-files
 ```
 
 ## Testing
+
 You can run the tests by typing the following command.
 
 ```
@@ -38,4 +46,5 @@ python -m unitttest
 ```
 
 ## License
+
 Unimport is MIT licensed, as found in the LICENSE file.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 ![unimport](https://raw.githubusercontent.com/hakancelik96/unimport/master/images/logo/Unimport.png)
 
-**A python CLI library to detect and auto remove unused Python imports by doing static code analysis.**
+**A python CLI library to detect and auto remove unused Python imports by doing static
+code analysis.**
 
-[![MIT License](https://img.shields.io/github/license/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/blob/master/LICENSE) [![releases](https://img.shields.io/github/release/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/releases) [![last-commit](https://img.shields.io/github/last-commit/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/commits/master) [![style](https://img.shields.io/badge/style-black-black)](https://github.com/psf/black) [![style](https://img.shields.io/badge/style-isort-lightgrey)](https://github.com/timothycrosley/isort) [![style](https://img.shields.io/badge/style-unimport-red)](https://github.com/hakancelik96/unimport) [![](https://img.shields.io/github/contributors/hakancelik96/unimport)](https://github.com/hakancelik96/unimport/graphs/contributors) [![](https://pepy.tech/badge/unimport)](https://pepy.tech/badge/unimport) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/unimport)
-
+[![MIT License](https://img.shields.io/github/license/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/blob/master/LICENSE)
+[![releases](https://img.shields.io/github/release/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/releases)
+[![last-commit](https://img.shields.io/github/last-commit/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/commits/master)
+[![style](https://img.shields.io/badge/style-black-black)](https://github.com/psf/black)
+[![style](https://img.shields.io/badge/style-isort-lightgrey)](https://github.com/timothycrosley/isort)
+[![style](https://img.shields.io/badge/style-unimport-red)](https://github.com/hakancelik96/unimport)
+[![](https://img.shields.io/github/contributors/hakancelik96/unimport)](https://github.com/hakancelik96/unimport/graphs/contributors)
+[![](https://pepy.tech/badge/unimport)](https://pepy.tech/badge/unimport)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/unimport)
 
 ## Getting Started
 
 ## Installation and Usage
+
 ### Installation
-Unimport requires Python 3.6+ and can be easily installed using most common Python packaging tools. We recommend installing the latest stable release from PyPI with pip:
+
+Unimport requires Python 3.6+ and can be easily installed using most common Python
+packaging tools. We recommend installing the latest stable release from PyPI with pip:
+
 ```
 pip install unimport
 ```
@@ -20,10 +32,13 @@ pip install unimport
 $ unimport [sources [sources ...]]
 ```
 
-*If you do not get any output, congratulations means there is no unused import in your project.*
+_If you do not get any output, congratulations means there is no unused import in your
+project._
 
 #### Let's with example with simple a Python code.
+
 **example.py**
+
 ```python
 import t
 from l import t
@@ -75,6 +90,7 @@ print(t)
 ```
 
 **-p ( permission ) command**
+
 ```python
 $ unimport example.py -p
 --- example.py
@@ -115,10 +131,11 @@ print(t)
 ```
 
 ## Command line options
+
 You can list many options by running unimport --help
 
 ```
-usage: unimport [-h] [-c PATH] [-d] [-r | -p] [--check] [-v] [sources [sources ...]]
+usage: unimport [-h] [-c PATH] [--include-star-import] [-d] [-r | -p] [--check] [-v] [sources [sources ...]]
 
 A python CLI library to detect and auto remove unused Python imports by doing static code analysis.
 
@@ -129,6 +146,8 @@ optional arguments:
   -h, --help            show this help message and exit
   -c PATH, --config PATH
                         read configuration from PATH.
+  --include-star-import
+                        Include star imports during scanning and refactor.
   -d, --diff            Prints a diff of all the changes unimport would make to a file.
   -r, --remove          remove unused imports automatically.
   -p, --permission      Refactor permission after see diff.
@@ -137,10 +156,12 @@ optional arguments:
 ```
 
 ## Configuring Unimport
-It's possible to configure **unimport** from `pyproject.toml` or `setup.cfg` files if you have.
 
-If you want to use `pyproject.toml` to configure, you must to install it.
-Try this; `pip install toml==0.10.0`
+It's possible to configure **unimport** from `pyproject.toml` or `setup.cfg` files if
+you have.
+
+If you want to use `pyproject.toml` to configure, you must to install it. Try this;
+`pip install toml==0.10.0`
 
 Use `exclude` config name to configure glob patterns for exluding files and folders.
 
@@ -166,7 +187,6 @@ exclude =  **/__init__.py
 **Please insert this badge into your project**
 
 `[![](https://img.shields.io/badge/style-unimport-red)](https://github.com/hakancelik96/unimport)`
-
 
 ## 🤝 [CONTRIBUTING.md](/CONTRIBUTING.md) 🤝
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![unimport](https://raw.githubusercontent.com/hakancelik96/unimport/master/images/logo/Unimport.png)
 
-**A python CLI library to detect and auto remove unused Python imports by doing static
-code analysis.**
+**A linter & formatter for finding & removing unused import statements.**
 
 [![MIT License](https://img.shields.io/github/license/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/blob/master/LICENSE)
 [![releases](https://img.shields.io/github/release/hakancelik96/unimport.svg)](https://github.com/hakancelik96/unimport/releases)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@
 
 ## Getting Started
 
+---
+
+**Contents:** **[Installation and Usage](#installation-and-usage)** |
+**[Command line options](#command-line-options)** |
+**[Configuring Unimport](#configuring-unimport)** |
+**[Adding pre-commit plugins to your project](#adding-pre-commit-plugins-to-your-project)**
+| **[Our badge](#our-badge-)** | **[CONTRIBUTING](#-contributingmd-)** |
+**[CHANGELOG.md](#changelogmd)** | **[Author / Social](#author--social)** |
+**[Who's using Unimport?](#whos-using-unimport)**
+
+---
+
 ## Installation and Usage
 
 ### Installation
@@ -52,7 +64,7 @@ from i import t, ii
 print(t)
 ```
 
-```
+```bash
 $ unimport example.py
 
 t at example.py:1
@@ -129,6 +141,21 @@ from i import t
 print(t)
 ```
 
+**Star Import** If you want to include star imports during scanning and refactor. Use
+command as follow. ``\$ unimport example.py --include-star-import`
+
+**Rare Cases** We add skip import feature to rare cases import statements.
+
+Leave '#unimport: skip' at the end of the line to skip imports with some rare cases.
+**for example:**
+
+```python
+try:
+  import django #unimport:skip
+except ImportError:
+  print("install django")
+```
+
 ## Command line options
 
 You can list many options by running unimport --help
@@ -181,6 +208,24 @@ exclude =  **/__init__.py
            tests*
 ```
 
+## Adding pre-commit plugins to your project
+
+Once you have [pre-commit](https://pre-commit.com/)
+[installed](https://pre-commit.com/#install), adding pre-commit plugins to your project
+is done with the .pre-commit-config.yaml configuration file.
+
+Add a file called .pre-commit-config.yaml to the root of your project. The pre-commit
+config file describes what repositories and hooks are installed.
+
+```yaml
+repos:
+  - repo: https://github.com/hakancelik96/unimport
+    rev: v0.2.6
+    hooks:
+      - id: unimport
+        args: [-r]
+```
+
 ## Our badge [![](https://img.shields.io/badge/style-unimport-red)](https://github.com/hakancelik96/unimport)
 
 **Please insert this badge into your project**
@@ -190,6 +235,10 @@ exclude =  **/__init__.py
 ## 🤝 [CONTRIBUTING.md](/CONTRIBUTING.md) 🤝
 
 [![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/0)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/0)[![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/1)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/1)[![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/2)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/2)[![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/3)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/3)[![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/4)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/4)[![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/5)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/5)[![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/6)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/6)[![](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/images/7)](https://sourcerer.io/fame/hakancelik96/hakancelik96/unimport/links/7)
+
+## [CHANGELOG.md](/CHANGELOG.md)
+
+All notable changes to this project will be documented in this file.
 
 ## Author / Social
 

--- a/rare_cases/case__all__.py
+++ b/rare_cases/case__all__.py
@@ -1,6 +1,0 @@
-# This is not unused import, but it is unused import according to unimport.
-
-# CASE 1
-from codeop import compile_command
-
-__all__ = ["compile_command"]

--- a/rare_cases/case_try_except.py
+++ b/rare_cases/case_try_except.py
@@ -1,6 +1,0 @@
-# This is not unused import, but it is unused import according to unimport.
-
-try:
-    import django
-except ImportError:
-    print("install django")

--- a/rare_cases/readme.md
+++ b/rare_cases/readme.md
@@ -1,2 +1,0 @@
-The cases here include rare cases that have been identified by unimport as unused
-imports example files but which are used imports.

--- a/rare_cases/readme.md
+++ b/rare_cases/readme.md
@@ -1,1 +1,2 @@
-The cases here include rare cases that have been identified by unimport as unused imports example files but which are used imports.
+The cases here include rare cases that have been identified by unimport as unused
+imports example files but which are used imports.

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -124,3 +124,39 @@ class TestNames(ScannerTestCase):
             expected_functions,
             expected_imports,
         )
+
+
+class SkipImportTest(ScannerTestCase):
+    def assertUnimportEqual(
+        self,
+        source,
+        expected_names=[],
+        expected_classes=[],
+        expected_functions=[],
+        expected_imports=[],
+    ):
+
+        super().assertUnimportEqual(
+            source,
+            expected_names,
+            expected_classes,
+            expected_functions,
+            expected_imports,
+        )
+
+    def test_inside_try_except(self):
+        source = (
+            "try:\n"
+            "   import django #unimport:skip\n"
+            "except ImportError:\n"
+            "   print('install django')\n"
+        )
+        self.assertUnimportEqual(source,)
+
+    def test_as_import(self):
+        source = "from x import y as z #unimport:skip\n"
+        self.assertUnimportEqual(source,)
+
+    def test_ongoing_comment(self):
+        source = "import unimport #unimport:skip import test\n"
+        self.assertUnimportEqual(source,)

--- a/tests/test_unused_import.py
+++ b/tests/test_unused_import.py
@@ -9,11 +9,12 @@ import unittest
 from unimport.session import Session
 
 
-class UnimportTestCase(unittest.TestCase):
+class UnusedTestCase(unittest.TestCase):
     maxDiff = None
+    include_star_import = False
 
     def setUp(self):
-        self.session = Session()
+        self.session = Session(include_star_import=self.include_star_import)
 
     def assertUnimportEqual(self, source, expected_nused_imports):
         self.session.scanner.run_visit(source)
@@ -23,7 +24,7 @@ class UnimportTestCase(unittest.TestCase):
         )
 
 
-class TestUnusedImport(UnimportTestCase):
+class TestUnusedImport(UnusedTestCase):
     def test_comma(self):
         source = "from os import (\n" "    waitpid,\n" "    scandir,\n" ")\n"
         expected_nused_imports = [
@@ -132,7 +133,9 @@ class TestUnusedImport(UnimportTestCase):
         self.assertUnimportEqual(source, expected_nused_imports)
 
 
-class TestStarImport(UnimportTestCase):
+class TestStarImport(UnusedTestCase):
+    include_star_import = True
+
     def test_unused(self):
         source = "from os import *\n"
         expected_nused_imports = [
@@ -236,7 +239,7 @@ class TestStarImport(UnimportTestCase):
         self.assertUnimportEqual(source, expected_nused_imports)
 
 
-class TestDuplicate(UnimportTestCase):
+class TestDuplicate(UnusedTestCase):
     def test_full_unused(self):
         source = (
             "from x import y\n"
@@ -848,7 +851,7 @@ class TestDuplicate(UnimportTestCase):
         self.assertUnimportEqual(source, expected_nused_imports)
 
 
-class TesAsImport(UnimportTestCase):
+class TesAsImport(UnusedTestCase):
     def test_as_import_all_unused_all_cases(self):
         source = (
             "from x import y as z\n"

--- a/tests/test_unused_import.py
+++ b/tests/test_unused_import.py
@@ -1,3 +1,4 @@
+import codeop
 import lib2to3.fixer_util
 import lib2to3.pgen2.token
 import lib2to3.pytree
@@ -25,6 +26,19 @@ class UnusedTestCase(unittest.TestCase):
 
 
 class TestUnusedImport(UnusedTestCase):
+    def test__all__from_import(self):
+        source = (
+            "from codeop import compile_command\n"
+            "__all__ = ['compile_command']"
+        )
+        expected_nused_imports = []
+        self.assertUnimportEqual(source, expected_nused_imports)
+
+    def test__all__star(self):
+        source = "from os import *\n" "__all__ = ['walk']"
+        expected_nused_imports = []
+        self.assertUnimportEqual(source, expected_nused_imports)
+
     def test_comma(self):
         source = "from os import (\n" "    waitpid,\n" "    scandir,\n" ")\n"
         expected_nused_imports = [
@@ -163,7 +177,6 @@ class TestStarImport(UnusedTestCase):
         self.assertUnimportEqual(source, expected_nused_imports)
 
     def test_used_and_unused(self):
-        # BUG the expected situation is not entirely correct.
         source = (
             "from lib2to3.fixer_util import *\n"
             "from lib2to3.pytree import *\n"
@@ -199,7 +212,6 @@ class TestStarImport(UnusedTestCase):
         self.assertUnimportEqual(source, expected_nused_imports)
 
     def test_used_and_unused_2(self):
-        # BUG the expected situation is not entirely correct.
         source = (
             "from lib2to3.fixer_util import *\n"
             "from lib2to3.pytree import *\n"
@@ -240,6 +252,23 @@ class TestStarImport(UnusedTestCase):
 
 
 class TestDuplicate(UnusedTestCase):
+    def test__all__(self):
+        source = (
+            "from codeop import compile_command\n"
+            "import compile_command\n"
+            "__all__ = ['compile_command']"
+        )
+        expected_nused_imports = [
+            {
+                "lineno": 1,
+                "module": codeop,
+                "modules": [],
+                "name": "compile_command",
+                "star": False,
+            }
+        ]
+        self.assertUnimportEqual(source, expected_nused_imports)
+
     def test_full_unused(self):
         source = (
             "from x import y\n"

--- a/unimport/__init__.py
+++ b/unimport/__init__.py
@@ -1,5 +1,7 @@
-__description__ = "A python CLI library to detect and auto remove unused Python imports by doing static code analysis."
-__version__ = "0.2.5"
+__description__ = (
+    "A linter & formatter for finding & removing unused import statements."
+)
+__version__ = "0.2.6"
 __author__ = (
     "Hakan Çelik <hakancelik96@outlook.com>, "
     "Batuhan Taşkaya <isidentical@gmail.com>, "

--- a/unimport/__main__.py
+++ b/unimport/__main__.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 
 from unimport import __description__, __version__
+from unimport.color import Color
 from unimport.session import Session
 
 parser = argparse.ArgumentParser(description=__description__)
@@ -21,6 +22,11 @@ parser.add_argument(
     help="read configuration from PATH.",
     metavar="PATH",
     type=pathlib.Path,
+)
+parser.add_argument(
+    "--include-star-import",
+    action="store_true",
+    help="Include star imports during scanning and refactor.",
 )
 parser.add_argument(
     "-d",
@@ -54,46 +60,102 @@ parser.add_argument(
 )
 
 
+def color_diff(sequence: tuple) -> str:
+    contents = "\n".join(sequence)
+    lines = contents.split("\n")
+    for i, line in enumerate(lines):
+        paint = Color(line)
+        if line.startswith("+++") or line.startswith("---"):
+            line = paint.bold_white
+        if line.startswith("@@"):
+            line = paint.cyan
+        if line.startswith("+"):
+            line = paint.green
+        elif line.startswith("-"):
+            line = paint.red
+        lines[i] = line
+    return "\n".join(lines)
+
+
 def print_if_exists(sequence):
     if sequence:
-        print(*sequence, sep="\n")
+        print(color_diff(sequence))
         return True
+
+
+def output(name, path, lineno, modules):
+    return (
+        f"{Color(name).yellow} at "
+        f"{Color(str(path)).green}:{Color(str(lineno)).green}"
+        f" {modules}"
+    )
+
+
+def get_modules(is_star: bool, modules: str) -> str:
+    if is_star:
+        _modules = ", ".join(modules)
+        if len(_modules) > 5:
+            modules = f"({_modules})"
+        elif len(_modules) == 0:
+            modules = ""
+        else:
+            modules = f"{_modules}"
+    else:
+        modules = ""
+    return modules
+
+
+def show(unused_import: list, py_path: str) -> None:
+    if not unused_import:
+        print(
+            Color(
+                "🐍 🕵️‍♂️ ✨ Congratulations there is no unused import in your project. ✨ 🕵️‍♂️ 🐍"
+            ).green
+        )
+    for imp in unused_import:
+        if (
+            (imp["star"] and imp["module"])
+            or (not imp["star"] and imp["module"])
+            and (not imp["star"] and not imp["module"])
+        ):
+            print(
+                output(
+                    imp["name"],
+                    py_path,
+                    imp["lineno"],
+                    get_modules(imp["star"], imp["modules"]),
+                )
+            )
 
 
 def main(argv=None):
     namespace = parser.parse_args(argv)
-    any_namespace = any([value for key, value in vars(namespace).items()][2:])
-    if namespace.permission and not namespace.diff:
-        namespace.diff = True
-    session = Session(config_file=namespace.config)
+    any_namespace = any([value for key, value in vars(namespace).items()][3:])
+    session = Session(
+        config_file=namespace.config,
+        include_star_import=namespace.include_star_import,
+    )
     for source_path in namespace.sources:
         for py_path in session._list_paths(source_path, "**/*.py"):
             if not any_namespace or namespace.check:
                 session.scanner.run_visit(source=session._read(py_path)[0])
-                for imp in session.scanner.get_unused_imports():
-                    if imp["star"]:
-                        modules = f"Used object; {imp['modules']}, "
-                    else:
-                        modules = ""
-                    print(
-                        f"\033[93m{imp['name']}\033[00m at "
-                        f"\033[92m{str(py_path)}:{imp['lineno']}\033[00m"
-                        f" {modules}"
-                    )
-
+                show(list(session.scanner.get_unused_imports()), py_path)
                 session.scanner.clear()
-            if namespace.diff:
+            if namespace.diff or namespace.permission:
                 exists_diff = print_if_exists(session.diff_file(py_path))
-                if namespace.permission and exists_diff:
-                    action = input(
-                        f"Apply suggested changes to \033[92m'{py_path}'\033[00m [y/n/q] ? >"
-                    )
-                    if action == "q":
-                        break
-                    elif action == "y":
-                        namespace.remove = True
+            if namespace.permission and exists_diff:
+                action = input(
+                    f"Apply suggested changes to '{Color(str(py_path)).yellow}' [y/n/q] ? >"
+                )
+                if action == "q":
+                    break
+                elif action == "y":
+                    namespace.remove = True
             if namespace.remove:
-                session.refactor_file(py_path, apply=True)
+                source = session._read(py_path)[0]
+                refactor_source = session.refactor_file(py_path, apply=True)
+                if refactor_source != source:
+                    print(f"Refactoring '{Color(str(py_path)).green}'")
 
 
 if __name__ == "__main__":

--- a/unimport/color.py
+++ b/unimport/color.py
@@ -1,0 +1,19 @@
+COLORS = {
+    "black": "\033[30m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "magenta": "\033[35m",
+    "cyan": "\033[36m",
+    "white": "\033[97m",
+    "bold_white": "\033[1;37m",
+}
+
+
+class Color:
+    reset = "\033[0m"
+
+    def __init__(self, content: str) -> None:
+        for name, code in COLORS.items():
+            setattr(self, name, code + content + self.reset)

--- a/unimport/refactor.py
+++ b/unimport/refactor.py
@@ -102,5 +102,10 @@ def refactor_string(source, unused_imports):
     except cst.ParserSyntaxError as err:
         print(f"\n\033[91m '{err}' \033[00m")
         return source
-    fixed_module = wrapper.visit(RemoveUnusedImportTransformer(unused_imports))
-    return fixed_module.code
+    if unused_imports:
+        fixed_module = wrapper.visit(
+            RemoveUnusedImportTransformer(unused_imports)
+        )
+        return fixed_module.code
+    else:
+        return source

--- a/unimport/refactor.py
+++ b/unimport/refactor.py
@@ -1,6 +1,8 @@
 import libcst as cst
 from libcst.metadata import MetadataWrapper, PositionProvider
 
+from unimport.color import Color
+
 
 class RemoveUnusedImportTransformer(cst.CSTTransformer):
     METADATA_DEPENDENCIES = [PositionProvider]
@@ -100,12 +102,11 @@ def refactor_string(source, unused_imports):
     try:
         wrapper = MetadataWrapper(cst.parse_module(source))
     except cst.ParserSyntaxError as err:
-        print(f"\n\033[91m '{err}' \033[00m")
-        return source
-    if unused_imports:
-        fixed_module = wrapper.visit(
-            RemoveUnusedImportTransformer(unused_imports)
-        )
-        return fixed_module.code
+        print(Color(str(err)).red)
     else:
-        return source
+        if unused_imports:
+            fixed_module = wrapper.visit(
+                RemoveUnusedImportTransformer(unused_imports)
+            )
+            return fixed_module.code
+    return source


### PR DESCRIPTION

- 💪 `--include-star-import command add` Include star imports during scanning and
  refactor.

- 🌈 color_diff add It shows the difference between source and refactor better.

- 🐞 All builtins names received during the scan have been fixed. Builtins names will no
  longer be offered as suggestions for star import.

- 🐞 If there is no unused import, the refactor error has been fixed.

- 💪 Import skip feature has been added. Leave '#unimport: skip' at the end of the line
  to skip imports with some rare cases. **for example:**

  ```python
  try:
    import django #unimport:skip
  except ImportError:
    print("install django")
  ```

- 💪 Added support for the rare case of **all**. **for example:**

  ```python
  from codeop import compile_command
  __all__ = ["compile_command"]
  ```