### PR TITLE
Extra type check on `utils.is_std` Fixes #148

### DIFF
--- a/unimport/utils.py
+++ b/unimport/utils.py
@@ -50,11 +50,15 @@ def is_std(package: str) -> bool:
     if package in C.BUILTIN_MODULE_NAMES:
         return True
     spec = get_spec(package)
-    return bool(spec) and isinstance(spec.origin, str) and any(
-        (
-            spec.origin.startswith(C.STDLIB_PATH),
-            spec.origin in ["built-in", "frozen"],
-            spec.origin.endswith(".so"),
+    return (
+        bool(spec)
+        and isinstance(spec.origin, str)
+        and any(
+            (
+                spec.origin.startswith(C.STDLIB_PATH),
+                spec.origin in ["built-in", "frozen"],
+                spec.origin.endswith(".so"),
+            )
         )
     )
 

--- a/unimport/utils.py
+++ b/unimport/utils.py
@@ -50,17 +50,16 @@ def is_std(package: str) -> bool:
     if package in C.BUILTIN_MODULE_NAMES:
         return True
     spec = get_spec(package)
-    return (
-        bool(spec)
-        and isinstance(spec.origin, str)
-        and any(
+    if spec and isinstance(spec.origin, str):
+        return any(
             (
                 spec.origin.startswith(C.STDLIB_PATH),
                 spec.origin in ["built-in", "frozen"],
                 spec.origin.endswith(".so"),
             )
         )
-    )
+    else:
+        return False
 
 
 @functools.lru_cache(maxsize=None)

--- a/unimport/utils.py
+++ b/unimport/utils.py
@@ -50,7 +50,7 @@ def is_std(package: str) -> bool:
     if package in C.BUILTIN_MODULE_NAMES:
         return True
     spec = get_spec(package)
-    return bool(spec) and any(
+    return bool(spec) and isinstance(spec.origin, str) and any(
         (
             spec.origin.startswith(C.STDLIB_PATH),
             spec.origin in ["built-in", "frozen"],


### PR DESCRIPTION
In case `spec.origin` is not `str`