### PR TITLE
%15 performance increase & remove show-error flag #155 #150

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unrelased - ./././
 
+- [%15 performance increase & remove show-error flag by @hakancelik96](https://github.com/hakancelik96/unimport/pull/159)
+
 - [💪 Star import more accurate suggestion by @hakancelik96](https://github.com/hakancelik96/unimport/pull/158)
 
   - #120 removed to implement it more accurately, later.

--- a/docs/README.md
+++ b/docs/README.md
@@ -168,16 +168,6 @@ from i import t
 print(t)
 ```
 
-## `--show-error` flag
-
-> Show or don't show errors captured during static analysis.
-
-Use this flag if you want to see errors ( like `SyntaxError` ) during analysis.
-
-### Usage
-
-- `$ unimport example.py --show-error`
-
 ## `--include-star-import` flag
 
 > Include star imports during scanning and refactor.
@@ -359,8 +349,8 @@ You can automatically delete unused modules from the requirements.txt file
 You can list many options by running unimport --help
 
 ```
-usage: unimport [-h] [-c PATH] [--include include] [--exclude exclude] [--gitignore] [--include-star-import] [--show-error]
-                [-d] [-r | -p] [--requirements] [--check] [-v]
+usage: unimport [-h] [-c PATH] [--include include] [--exclude exclude] [--gitignore] [--include-star-import] [-d] [-r | -p]
+                [--requirements] [--check] [-v]
                 [sources [sources ...]]
 
 A linter, formatter for finding and removing unused import statements.
@@ -377,7 +367,6 @@ optional arguments:
   --gitignore           exclude .gitignore patterns. if present.
   --include-star-import
                         Include star imports during scanning and refactor.
-  --show-error          Show or don't show errors captured during static analysis.
   -d, --diff            Prints a diff of all the changes unimport would make to a file.
   -r, --remove          remove unused imports automatically.
   -p, --permission      Refactor permission after see diff.
@@ -411,7 +400,6 @@ requirements = true
 remove = false
 diff = true
 include_star_import = true
-show_error = false
 ```
 
 **setup.cfg**
@@ -426,7 +414,6 @@ requirements = true
 remove = false
 diff = true
 include_star_import = true
-show_error = false
 ```
 
 **When reading your configurations, it gives priority to the configurations you enter

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -9,7 +9,6 @@ from unimport.statement import Import, ImportFrom, Name
 class ScannerTestCase(unittest.TestCase):
     maxDiff = None
     include_star_import = False
-    show_error = False
 
     def assertUnimportEqual(
         self,
@@ -20,7 +19,6 @@ class ScannerTestCase(unittest.TestCase):
         scanner = Scanner(
             source=textwrap.dedent(source),
             include_star_import=self.include_star_import,
-            show_error=self.show_error,
         )
         scanner.traverse()
         self.assertEqual(expected_names, scanner.names)
@@ -115,7 +113,6 @@ class TestNames(ScannerTestCase):
 
 class TestStarImport(ScannerTestCase):
     include_star_import = True
-    show_error = True
 
     def test_star(self):
         self.assertUnimportEqual(

--- a/unimport/config.py
+++ b/unimport/config.py
@@ -22,7 +22,6 @@ class DefaultConfig(NamedTuple):
     remove: bool = False
     diff: bool = False
     include_star_import: bool = False
-    show_error: bool = False
     permission: bool = False
     check: bool = False
 

--- a/unimport/main.py
+++ b/unimport/main.py
@@ -89,12 +89,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         default=default_config.include_star_import,
     )
     parser.add_argument(
-        "--show-error",
-        action="store_true",
-        help="Show or don't show errors captured during static analysis.",
-        default=default_config.show_error,
-    )
-    parser.add_argument(
         "-d",
         "--diff",
         action="store_true",
@@ -152,7 +146,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             scanner = Scanner(
                 source=source,
                 include_star_import=config.include_star_import,
-                show_error=config.show_error,
             )
             scanner.traverse()
             unused_imports = list(scanner.get_unused_imports())
@@ -206,10 +199,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                     requirement.split("==")[0]
                 )
                 if module_name is None:
-                    if config.show_error:
-                        print(
-                            color.paint(requirement + " not found", color.RED)
-                        )
+                    print(color.paint(requirement + " not found", color.RED))
                     continue
                 if module_name not in used_packages:
                     copy_source.remove(requirement)


### PR DESCRIPTION
PR; #155 

ISSUE; #150

```
74099703 function calls (66262458 primitive calls) in 19.979 seconds

   Ordered by: internal time
   List reduced from 1867 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
3428575/2876    3.579    0.000   12.281    0.004 /usr/lib/python3.8/ast.py:365(generic_visit)
 14623557    2.612    0.000    3.532    0.000 /usr/lib/python3.8/ast.py:202(iter_fields)
  4076011    1.685    0.000    3.340    0.000 /usr/lib/python3.8/ast.py:214(iter_child_nodes)
 12945709    1.632    0.000    1.632    0.000 {built-in method builtins.getattr}
3496521/2876    1.586    0.000   12.285    0.004 /usr/lib/python3.8/ast.py:359(visit)
19365629/19360001    1.470    0.000    1.472    0.000 {built-in method builtins.isinstance}
     5091    1.318    0.000    1.318    0.000 {built-in method builtins.compile}
  1261337    0.561    0.000    2.956    0.000 /usr/lib/python3.8/ast.py:325(walk)
     4635    0.437    0.000    4.010    0.001 /home/hakan/Desktop/unimport/unimport/relate.py:7(relate)
640019/52745    0.410    0.000    9.764    0.000 /home/hakan/Desktop/unimport/unimport/scan.py:19(wrapper)
```