### PR TITLE
Fix EOLs not being respected in modified files per #183

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: v0.910
     hooks:
       - id: mypy
-        args: [--no-strict-optional, --ignore-missing-imports]
+        args: [--no-strict-optional, --ignore-missing-imports, --show-error-codes]
         additional_dependencies: [types-toml==0.1.3]
 
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -8,6 +8,7 @@
 
 <!-- Please write your name alphabetically. -->
 
+- C.A.M. Gerlach (@CAM-Gerlach) <CAM.Gerlach@Gerlach.CAM>
 - Furkan Önder (@furkanonder) <furkanonder@protonmail.com>
 - Hadi Alqattan (@hadialqattan) <alqattanhadizaki@gmail.com>
 - Işık Kaplan (@isik-kaplan) <isik.kaplan@outlook.com>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased] - ././2021
 
-- []()
+- [🐞 🧪 Fix EOLs not being respected in modified files per #183 by @CAM-Gerlach](https://github.com/hakancelik96/unimport/pull/193)
+  - Respect the file's current EOL (LF/CRLF) instead of the platform default
+  - Add unit and integration tests that EOLs are respected
 
 ## [0.9.0] - 5/September/2021
 

--- a/tests/test_linesep.py
+++ b/tests/test_linesep.py
@@ -3,7 +3,7 @@ import unittest
 
 import unimport.main
 import unimport.utils
-from tests.utils import reopenable_temp_file
+from tests.utils import get_non_native_linesep, reopenable_temp_file
 
 
 class LineSepTestCase(unittest.TestCase):
@@ -32,10 +32,7 @@ class LineSepTestCase(unittest.TestCase):
             self.assertEqual(self.result, unimport.utils.read(tmp_path)[0])
 
     def test_non_platform_native_linesep(self):
-        if os.linesep == "\n":
-            non_os_sep = "\r\n"
-        else:
-            non_os_sep = "\n"
+        non_os_sep = get_non_native_linesep()
         with reopenable_temp_file(self.source, newline=non_os_sep) as tmp_path:
             unimport.main.main(["--remove", tmp_path.as_posix()])
             with open(tmp_path, encoding="utf-8") as tmp_py_file:

--- a/tests/test_linesep.py
+++ b/tests/test_linesep.py
@@ -31,7 +31,6 @@ class LineSepTestCase(unittest.TestCase):
                 self.assertEqual(os.linesep, tmp_py_file.newlines)
             self.assertEqual(self.result, unimport.utils.read(tmp_path)[0])
 
-    @unittest.expectedFailure
     def test_non_platform_native_linesep(self):
         if os.linesep == "\n":
             non_os_sep = "\r\n"

--- a/tests/test_linesep.py
+++ b/tests/test_linesep.py
@@ -1,0 +1,45 @@
+import os
+import unittest
+
+import unimport.main
+import unimport.utils
+from tests.utils import reopenable_temp_file
+
+
+class LineSepTestCase(unittest.TestCase):
+    source = "\n".join(
+        [
+            "import os",
+            "import sys",
+            "",
+            "print(sys.executable)\n",
+        ]
+    )
+    result = "\n".join(
+        [
+            "import sys",
+            "",
+            "print(sys.executable)\n",
+        ]
+    )
+
+    def test_platform_native_linesep(self):
+        with reopenable_temp_file(self.source, newline=os.linesep) as tmp_path:
+            unimport.main.main(["--remove", tmp_path.as_posix()])
+            with open(tmp_path, encoding="utf-8") as tmp_py_file:
+                tmp_py_file.read()
+                self.assertEqual(os.linesep, tmp_py_file.newlines)
+            self.assertEqual(self.result, unimport.utils.read(tmp_path)[0])
+
+    @unittest.expectedFailure
+    def test_non_platform_native_linesep(self):
+        if os.linesep == "\n":
+            non_os_sep = "\r\n"
+        else:
+            non_os_sep = "\n"
+        with reopenable_temp_file(self.source, newline=non_os_sep) as tmp_path:
+            unimport.main.main(["--remove", tmp_path.as_posix()])
+            with open(tmp_path, encoding="utf-8") as tmp_py_file:
+                tmp_py_file.read()
+                self.assertEqual(non_os_sep, tmp_py_file.newlines)
+            self.assertEqual(self.result, unimport.utils.read(tmp_path)[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,4 +68,4 @@ class UtilsTestCase(unittest.TestCase):
     def test_read(self):
         source = "b�se"
         with reopenable_temp_file(source) as tmp_path:
-            self.assertEqual((source, "utf-8"), utils.read(tmp_path))
+            self.assertEqual((source, "utf-8", None), utils.read(tmp_path))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
+import os
 import unittest
 from pathlib import Path
 
-from tests.utils import reopenable_temp_file
+from tests.utils import get_non_native_linesep, reopenable_temp_file
 from unimport import utils
 from unimport.analyzer import Analyzer
 from unimport.refactor import refactor_string
@@ -11,6 +12,13 @@ from unimport.statement import Import
 class UtilsTestCase(unittest.TestCase):
     maxDiff = None
     include_star_import = True
+    source = "\n".join(
+        [
+            "import sys",
+            "",
+            "print(sys.executable)\n",
+        ]
+    )
 
     def test_list_paths(self):
         self.assertEqual(len(list(utils.list_paths(Path("tests")))), 33)
@@ -69,3 +77,18 @@ class UtilsTestCase(unittest.TestCase):
         source = "b�se"
         with reopenable_temp_file(source) as tmp_path:
             self.assertEqual((source, "utf-8", None), utils.read(tmp_path))
+
+    def test_read_newline_native(self):
+        with reopenable_temp_file(self.source, newline=os.linesep) as tmp_path:
+            self.assertEqual(
+                (self.source, "utf-8", os.linesep),
+                utils.read(tmp_path),
+            )
+
+    def test_read_newline_nonnative(self):
+        non_os_sep = get_non_native_linesep()
+        with reopenable_temp_file(self.source, newline=non_os_sep) as tmp_path:
+            self.assertEqual(
+                (self.source, "utf-8", get_non_native_linesep()),
+                utils.read(tmp_path),
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,35 +1,11 @@
-import os
-import tempfile
 import unittest
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
 
+from tests.utils import reopenable_temp_file
 from unimport import utils
 from unimport.analyzer import Analyzer
 from unimport.refactor import refactor_string
 from unimport.statement import Import
-
-
-@contextmanager
-def reopenable_temp_file(content: str) -> Iterator[Path]:
-    """Reopenable tempfile to support writing/reading to/from the opened
-    tempfile (requiered for Windows OS).
-
-    For more information: https://bit.ly/3cr0Qkl
-
-    :param content: string content to write.
-    :yields: tempfile path.
-    """
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".py", encoding="utf-8", delete=False
-        ) as tmp:
-            tmp_path = Path(tmp.name)
-            tmp.write(content)
-        yield tmp_path
-    finally:
-        os.unlink(tmp_path)
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -37,7 +13,7 @@ class UtilsTestCase(unittest.TestCase):
     include_star_import = True
 
     def test_list_paths(self):
-        self.assertEqual(len(list(utils.list_paths(Path("tests")))), 31)
+        self.assertEqual(len(list(utils.list_paths(Path("tests")))), 33)
         self.assertEqual(
             len(list(utils.list_paths(Path("tests/test_config.py")))), 1
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,34 @@
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+
+@contextmanager
+def reopenable_temp_file(
+    content: str, newline: Optional[str] = None
+) -> Iterator[Path]:
+    """Create a reopenable tempfile to supporting multiple reads/writes.
+
+    Required to avoid file locking issues on Windows.
+    For more information, see:
+    https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
+
+    :param content: string content to write.
+    :param newline: Newline character to use, if not platform default.
+    :yields: tempfile path.
+    """
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            encoding="utf-8",
+            newline=newline,
+            delete=False,
+        ) as tmp:
+            tmp_path = Path(tmp.name)
+            tmp.write(content)
+        yield tmp_path
+    finally:
+        os.unlink(tmp_path)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,14 @@ from pathlib import Path
 from typing import Iterator, Optional
 
 
+def get_non_native_linesep() -> str:
+    """Return an end of line character not native to the current platform."""
+    if os.linesep == "\n":
+        return "\r\n"
+    else:
+        return "\n"
+
+
 @contextmanager
 def reopenable_temp_file(
     content: str, newline: Optional[str] = None

--- a/unimport/color.py
+++ b/unimport/color.py
@@ -40,13 +40,17 @@ if sys.platform == "win32":  # pragma: no cover (windows)
             ("GetConsoleMode", windll.kernel32),
             ((1, "hConsoleHandle"), (2, "lpMode")),
         )
-        GetConsoleMode.errcheck = bool_errcheck
+        GetConsoleMode.errcheck = (  # type: ignore[assignment, misc]
+            bool_errcheck  # type: ignore[assignment]
+        )
 
         SetConsoleMode = WINFUNCTYPE(BOOL, HANDLE, DWORD)(
             ("SetConsoleMode", windll.kernel32),
             ((1, "hConsoleHandle"), (1, "dwMode")),
         )
-        SetConsoleMode.errcheck = bool_errcheck
+        SetConsoleMode.errcheck = (  # type: ignore[assignment, misc]
+            bool_errcheck  # type: ignore[assignment]
+        )
 
         # As of Windows 10, the Windows console supports (some) ANSI escape
         # sequences, but it needs to be enabled using `SetConsoleMode` first.

--- a/unimport/main.py
+++ b/unimport/main.py
@@ -128,7 +128,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         for py_path in utils.list_paths(
             source_path, config.include, config.exclude
         ):
-            source, encoding = utils.read(py_path)
+            source, encoding, newline = utils.read(py_path)
             analyzer = Analyzer(
                 source=source,
                 path=py_path,
@@ -189,7 +189,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                 elif utils.actiontobool(action):
                     config = config._replace(remove=True)
             if config.remove and source != refactor_result:
-                py_path.write_text(refactor_result, encoding=encoding)
+                with open(
+                    py_path, mode="w", encoding=encoding, newline=newline
+                ) as py_file:
+                    py_file.write(refactor_result)
                 print(
                     f"Refactoring '{color.paint(str(py_path), color.GREEN)}'"
                 )

--- a/unimport/utils.py
+++ b/unimport/utils.py
@@ -112,7 +112,7 @@ def get_exclude_list_from_gitignore() -> List[str]:
     path = Path(".gitignore")
     gitignore_regex: List[str] = []
     if path.is_file():
-        source, _ = read(path)
+        source, _, _ = read(path)
         for line in source.splitlines():
             regex = GitWildMatchPattern.pattern_to_regex(line)[0]
             if regex:
@@ -120,14 +120,18 @@ def get_exclude_list_from_gitignore() -> List[str]:
     return gitignore_regex
 
 
-def read(path: Path) -> Tuple[str, str]:
+def read(path: Path) -> Tuple[str, str, Optional[str]]:
     try:
         with tokenize.open(path) as stream:
             source = stream.read()
             encoding = stream.encoding
-    except (OSError, SyntaxError) as err:
-        return "", "utf-8"
-    return source, encoding
+            newline = stream.newlines
+    except (OSError, SyntaxError):
+        return "", "utf-8", None
+    # If mixed or unknown newlines, fall back to the platform default
+    if not isinstance(newline, str):
+        newline = None
+    return source, encoding, newline
 
 
 def list_paths(


### PR DESCRIPTION
<!--
## Review the Contributing Guidelines

Before submitting a pull request, verify it meets all requirements in the
[Contributing Guidelines](https://github.com/hakancelik96/unimport/blob/master/docs/CONTRIBUTING.md).
-->

* [x] Fix unhandled ctypes-related MyPy errors on Windows causing committing to fail
* [x] Add regression tests for issue #183
* [x] Fix #183 : Respect current file EoLs instead of coercing to platform default
* [x] Add unit tests for new `utils.read()` functionality
* [x] Pre-commit all passes locally
* [x] Test suite all passes locally
* [ ] Add changelog entry? [Awaiting maintainer guidance given lack of unreleased section and non-standards-conformant format]

Typically with Pytest, the idiomatic approach would of course be using fixtures and parametrize maximize code re-use and minimize duplication, but given the existing tests all appear to conform to legacy unittest conventions, I followed the latter rather than the former, thus the non-trivial amount of similar code. I also pulled the common persistent temporary file context manager into a separate utility module, as was done elsewhere, to avoid duplication between test modules. As I'm not very familiar with using unittest for serious projects, let me know if there's any convention/patterns I should be following but didn't.

Fix #183